### PR TITLE
Исправлена неправильная смена статуса заказа

### DIFF
--- a/src/core/components/yandexmoney/model/yandexmoney.class.php
+++ b/src/core/components/yandexmoney/model/yandexmoney.class.php
@@ -227,7 +227,7 @@ class Yandexmoney {
 			}else{
 				$this->sendCode($callbackParams, $code);
 			}
-			exit;
+			return;
 		}else{
 			return $code;
 		}
@@ -253,9 +253,9 @@ class Yandexmoney {
 			if ($callbackParams['action'] == 'checkOrder'){
 				$code = $this->checkOrder($callbackParams);
 				$this->sendCode($callbackParams, $code);
-				$order_id = (int)$callbackParams["orderNumber"];
 			}
 			if ($callbackParams['action'] == 'paymentAviso'){
+				$order_id = (int)$callbackParams["orderNumber"];
 				$this->checkOrder($callbackParams, TRUE, TRUE);
 			}
 		}else{

--- a/src/elements/snippets/YandexMoneyHook.php
+++ b/src/elements/snippets/YandexMoneyHook.php
@@ -20,7 +20,7 @@ if (!empty($_POST['payment'])){
 	$ym->pay_method = $_POST['payment'];
 }
 if (!$ym->checkPayMethod()){
-	return false;
+	return true;
 }
 
 $modx->addPackage('shopkeeper', MODX_CORE_PATH."components/shopkeeper/model/");


### PR DESCRIPTION
При получении ответа 'checkOrder' статус заказа менялся на "Оплата получена". При переносе в секцию 'paymentAviso', скрипт не отрабатывал, т.к. в методе checkOrder выход стоял по exit, заменил на return